### PR TITLE
Added additional check to date inputs.

### DIFF
--- a/R/wp_check_date_inputs.R
+++ b/R/wp_check_date_inputs.R
@@ -2,7 +2,7 @@
 #' 
 #' Function that checks if the time span given by from and to (passed down from
 #' wp_trend) are complying with logical constraints: from not prior to first
-#' available data; to not past today
+#' available data; to not past today; to not prior to from
 #' 
 #' @param from first date of timespan to check
 #' @param to second date of timespan to check
@@ -11,10 +11,15 @@ wp_check_date_inputs <- function(from, to){
   from <- as.character(from)
   to <- as.character(to)
   if ( wp_date(from) < wp_date("2007-12-01")  ) { 
-  from <- wp_date("2007-12-01")
+    from <- wp_date("2007-12-01")
   } 
   if ( wp_date(to) > Sys.Date()  ) { 
     to <- Sys.Date()
   } 
+  if ( wp_date(to) < wp_date(from) ) {
+    from.saved <- from
+    from <- to
+    to <- from.saved
+  }
   return( list(from=from, to=to) )
 }


### PR DESCRIPTION
I added an additional check of the date inputs: that the 'to' date is higher than 'from' date. If it is not then the 'to' and 'from' are exchanged, so that 'to' becomes 'from' and 'from' becomes 'to'. It could instead simply throw an error message, but I though it would be more robust like this.
Right now, giving a 'to' lower than 'from' throws an uninformative error message:
"Error in seq.int(0, to0 - from, by) : wrong sign in 'by' argument"