### PR TITLE
Alternative friendly behaviour

### DIFF
--- a/R/wp_friendly_save.R
+++ b/R/wp_friendly_save.R
@@ -13,8 +13,8 @@ wp_friendly_save <- function(res, friendly, resname){
   if ( friendly==1 | friendly==2 ) {
     if ( friendly==1 ) write.csv(res, resname)
     if ( friendly==2 ) write.csv2(res, resname)
-    message(paste0("\nResults written to:\n", getwd(), "/", resname ,"\n"))
-    return( paste0(getwd(),"/",resname) )
+    message(paste0("\nResults written to:\n", normalizePath(resname) ,"\n"))
+    return( resname )
   }
   return(FALSE)
 }

--- a/R/wp_trend.R
+++ b/R/wp_trend.R
@@ -41,6 +41,11 @@
 #'   requests: \code{paste( "wikipediatrend running on: ", R.version$platform,
 #'   R.version$version.string, sep=", ")}
 #'   
+#' @param dataDir Directory where data will be stored if friendly is set to 
+#'   \code{TRUE}, \code{1} or \code{2}. If this option is not set, the data will
+#'   be stored in a temporary folder and will be retrieved in subsequent calls if
+#'   during the same R session.
+#'   
 #' @examples 
 #' wp_trend(page        = "Main_Page", 
 #'          from        = "2014-11-01", 
@@ -48,15 +53,17 @@
 #'          lang        = "en", 
 #'          friendly    = FALSE, 
 #'          requestFrom = "wp.trend.tester at wptt.wptt",
-#'          userAgent   =   TRUE)
+#'          userAgent   =   TRUE,
+#'          dataDir     = "../data")
 
 wp_trend <- function( page        = "Peter_principle", 
                       from        = Sys.Date()-30, 
                       to          = Sys.Date(),
                       lang        = "en", 
-                      friendly    = F,
+                      friendly    = T,
                       requestFrom = "anonymous",
-                      userAgent   = F
+                      userAgent   = F,
+                      dataDir     = ""
 ){
   # encourage being freindly
   if ( !friendly ) {
@@ -80,8 +87,10 @@ wp_trend <- function( page        = "Peter_principle",
                                                   sep=", "))
   }
   
-  # file name for beeing friendly
-  resname <- paste0("wp", "__", page, "__", lang, ".csv")
+  # data directory and file name for being friendly
+  if ( dataDir == "" ) dataDir <- tempdir()
+  if ( substr(dataDir, nchar(dataDir), nchar(dataDir)) != "/" ) dataDir <- paste0(dataDir, "/")
+  resname <- paste0(dataDir, "wp", "__", page, "__", lang, ".csv")
   
   # check dates
   tmp  <- wp_check_date_inputs(from, to)


### PR DESCRIPTION
This is a suggestion for an alternative behaviour for the friendly option:
1) Making the friendly = TRUE the default. As the data doesn't change every time we fetch it, it really doesn't make sense not caching the data.
2) Include additional parameter 'dataDir' with path to the place where data is to be stored. I think that very often the user will have a particular directory to store the data and having to change the working directory to have the data stored in the right place is not user friendly.
3) In case where dataDir is not defined, use a temporary folder which will last for the remaining of the R session. This goes together with 1) above, as the user might not want to have the data files floating around in his/her directory struture if he/she didn't ask for it.