### PR TITLE
Friendly CSV file without row names

### DIFF
--- a/R/wp_friendly_save.R
+++ b/R/wp_friendly_save.R
@@ -11,8 +11,8 @@
 
 wp_friendly_save <- function(res, friendly, resname){
   if ( friendly==1 | friendly==2 ) {
-    if ( friendly==1 ) write.csv(res, resname)
-    if ( friendly==2 ) write.csv2(res, resname)
+    if ( friendly==1 ) write.csv(res, resname, row.names=FALSE)
+    if ( friendly==2 ) write.csv2(res, resname, row.names=FALSE)
     message(paste0("\nResults written to:\n", getwd(), "/", resname ,"\n"))
     return( paste0(getwd(),"/",resname) )
   }


### PR DESCRIPTION
The CSV files were being written with rownames. It doesn't seem to have any negative impact, but the rownames were not meaningful (for the newly added rows it's the date for the previously existing ones it's a sequential number with some random order).
I think that without the rownames the CSV files will look more professional and they will also take less disk space.